### PR TITLE
if response comes without pdf add a null instead of index not found.

### DIFF
--- a/src/ApiResult.php
+++ b/src/ApiResult.php
@@ -54,7 +54,7 @@ class ApiResult
 
         $apiResponse = new static();
 
-        $apiResponse->pdf = $data['pdf'];
+        $apiResponse->pdf = isset($data['pdf'])?$data['pdf']: null;
         $apiResponse->mbIn = $data['mbIn'];
         $apiResponse->mbOut = $data['mbOut'];
         $apiResponse->cost = $data['cost'];


### PR DESCRIPTION
it happends after delete a pdf.

the anwer from api is: 

 '{
  "mbIn": 0.0,
  "mbOut": 0.0,
  "cost": 6.4011E-05,
  "success": true,
  "error": null,
  "responseId": "46b3ab82-aaa2-4103-a856-5ea5b515962e"
}' 

there is no pdf file, which is correct, but there is a warning after trying to get that inexistent field.